### PR TITLE
Initial AWS VPC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+config.local.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+---
+network:
+  - name: cardano-node

--- a/runme.sh
+++ b/runme.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env
+
+cd terraform && terraform init && terraform plan

--- a/terraform/locals.aws.tf
+++ b/terraform/locals.aws.tf
@@ -1,0 +1,27 @@
+locals {
+  aws_default_region = "us-east-2"
+
+  aws_vpc_default = { for i, vpc in local.network_vars :
+    vpc.name => vpc if try(vpc.enabled, true) &&
+    try(vpc.cloud_provider, "aws") == "aws" &&
+    try(vpc.region, "") == ""
+  }
+
+  aws_vpc_sa_east1 = { for i, vpc in local.network_vars :
+    vpc.name => vpc if try(vpc.enabled, true) &&
+    try(vpc.cloud_provider, "aws") == "aws" &&
+    try(vpc.region, "") == "sa-east-1"
+  }
+
+  aws_vpc_us_east1 = { for i, vpc in local.network_vars :
+    vpc.name => vpc if try(vpc.enabled, true) &&
+    try(vpc.cloud_provider, "aws") == "aws" &&
+    try(vpc.region, "") == "us-east-1"
+  }
+
+  aws_vpc_us_east2 = { for i, vpc in local.network_vars :
+    vpc.name => vpc if try(vpc.enabled, true) &&
+    try(vpc.cloud_provider, "aws") == "aws" &&
+    try(vpc.region, "") == "us-east-2"
+  }
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  config       = try(yamldecode(file("../config.yaml")), {})
+  network_vars = try(local.config["network"], [])
+}

--- a/terraform/network.aws.tf
+++ b/terraform/network.aws.tf
@@ -1,0 +1,83 @@
+module "aws_vpc_default" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
+
+  providers = {
+    aws = aws
+  }
+
+  for_each = local.aws_vpc_default
+
+  name = each.value.name
+
+  cidr            = try(each.value.cidr, "10.0.0.0/16")
+  azs             = try(each.value.azs, ["us-east-2c"])
+  private_subnets = try(each.value.private_subnets, ["10.0.1.0/24"])
+  public_subnets  = try(each.value.public_subnets, ["10.0.101.0/24"])
+
+  enable_dns_hostnames = true
+  enable_nat_gateway   = false
+}
+
+module "aws_vpc_sa_east1" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
+
+  providers = {
+    aws = aws.sa-east-1
+  }
+
+  for_each = local.aws_vpc_sa_east1
+
+  name = each.value.name
+
+  cidr            = try(each.value.cidr, "10.0.0.0/16")
+  azs             = try(each.value.azs, ["us-east-1c"])
+  private_subnets = try(each.value.private_subnets, ["10.0.1.0/24"])
+  public_subnets  = try(each.value.public_subnets, ["10.0.101.0/24"])
+
+  enable_dns_hostnames = true
+  enable_nat_gateway   = false
+}
+
+module "aws_vpc_us_east1" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  for_each = local.aws_vpc_us_east1
+
+  name = each.value.name
+
+  cidr            = try(each.value.cidr, "10.0.0.0/16")
+  azs             = try(each.value.azs, ["us-east-1c"])
+  private_subnets = try(each.value.private_subnets, ["10.0.1.0/24"])
+  public_subnets  = try(each.value.public_subnets, ["10.0.101.0/24"])
+
+  enable_dns_hostnames = true
+  enable_nat_gateway   = false
+}
+
+module "aws_vpc_us_east2" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
+
+  providers = {
+    aws = aws.us-east-2
+  }
+
+  for_each = local.aws_vpc_us_east2
+
+  name = each.value.name
+
+  cidr            = try(each.value.cidr, "10.0.0.0/16")
+  azs             = try(each.value.azs, ["us-east-2c"])
+  private_subnets = try(each.value.private_subnets, ["10.0.1.0/24"])
+  public_subnets  = try(each.value.public_subnets, ["10.0.101.0/24"])
+
+  enable_dns_hostnames = true
+  enable_nat_gateway   = false
+}

--- a/terraform/providers.aws.tf
+++ b/terraform/providers.aws.tf
@@ -1,0 +1,21 @@
+# Since terraform does not allow dynamic providers, we need one for each region
+
+# Our default, if no region is provided, is to use us-east-2
+provider "aws" {
+  region = local.aws_default_region
+}
+
+provider "aws" {
+  alias  = "sa-east-1"
+  region = "sa-east-1"
+}
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us-east-2"
+  region = "us-east-2"
+}

--- a/terraform/versions.aws.tf
+++ b/terraform/versions.aws.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "> 1.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.56.0"
+    }
+  }
+}


### PR DESCRIPTION
Create standalone VPCs. Support us-east-1, us-east-2, and sa-east-1
regions. If no region is given, default to us-east-2 to avoid us-east-1
heavy utilization.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>