### PR TITLE
feat: Add ability to provision AWS virtualmachines

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,17 @@ objectstorage:
   - name: "cardano-node-cloudinit-metadata"
     acl: "public-read"
     logging: true
+  - name: "cardano-node-bootstrap"
+    versioning: true
+    bootstrap: true
 
 nosql:
   - name: "terraform-state-locking"
     billing_mode: "PAY_PER_REQUEST"
     terraform_state: true
+
+virtual_machines:
+  default_instance_type: "m6g.large"
+  instances:
+    - name: "cardano-node"
+      block_producer: true

--- a/templates/cloudinit/cardano-node.tftpl
+++ b/templates/cloudinit/cardano-node.tftpl
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+apt-get install -y awscli jq unzip python3-pip python3-venv python3-docker
+
+export AWS_DEFAULT_REGION=$(curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+INSTANCE_IP=$(ip route get 1.2.3.4 | grep via | awk '{ print $7 }')
+
+###
+# Mount data volume
+
+VOLUME_ID=${EBS_VOLUME_ID}
+NVME_DEVICE=nvme1n1
+MOUNT_DIR=/data
+
+(
+set -x
+ATTACHED=0
+until [ "$ATTACHED" -eq 1 ]
+do
+  ATTACHED_INSTANCE=$(aws ec2 describe-volumes --volume-ids "$VOLUME_ID" | jq -r '.Volumes[] | .Attachments[].InstanceId' | sort -u)
+  echo "INFO: Attached instance: ${ATTACHED_INSTANCE}"
+  if [[ "$ATTACHED_INSTANCE" == "$INSTANCE_ID" ]]; then
+    echo "INFO: EBS Volume ${VOLUME_ID} attached to instance ${INSTANCE_ID} already."
+    ATTACHED=1
+  else
+    aws ec2 attach-volume --volume-id "$VOLUME_ID" --instance-id "$INSTANCE_ID" --device /dev/sdf
+    if test $? -eq 0; then
+      echo "INFO: Attached EBS Volume ${VOLUME_ID} to instance ${INSTANCE_ID}."
+      ATTACHED=1
+    else
+      echo "Failed to attach EBS volume, retrying after 2s pause..."
+      sleep 2
+    fi
+  fi
+done
+)
+
+# Wait for device to show up
+while true; do
+  [[ -e /sys/block/${NVME_DEVICE} ]] && break
+  echo "Waiting for device ${NVME_DEVICE} to appear..."
+  sleep 2
+done
+
+set -x
+
+# Check for existing filesystem, and format if none found
+if ! dumpe2fs /dev/${NVME_DEVICE} >& /dev/null; then
+  mkfs.ext4 /dev/${NVME_DEVICE}
+fi
+
+mkdir -p ${MOUNT_DIR}
+
+echo "/dev/${NVME_DEVICE}  ${MOUNT_DIR}  ext4  noatime  0  0" >> /etc/fstab
+
+mount ${MOUNT_DIR}
+
+###
+# Swap file
+SWAP_FILE=${MOUNT_DIR}/swap.file
+if ! test -e ${SWAP_FILE}; then
+  dd if=/dev/zero of=${SWAP_FILE} bs=1M count=10240
+  chmod 0600 ${SWAP_FILE}
+  mkswap ${SWAP_FILE}
+  echo "${SWAP_FILE}  none  swap  sw  0  0" >> /etc/fstab
+fi
+swapon ${SWAP_FILE}
+
+###
+# Run Ansible
+
+python3 -m venv /root/.venv
+. /root/.venv/bin/activate
+aws s3 cp s3://${OBJECT_STORAGE_BOOTSTRAP_BUCKET}/ansible.zip /root/ansible.zip
+mkdir /root/ansible
+cd /root/ansible
+unzip -o /root/ansible.zip
+pip install ansible==6.6.0 docker requests
+ansible-galaxy install -r requirements.yml
+ansible-playbook \
+  local.yml \
+  -e POOL=${CARDANO_POOL_NAME} \
+  -e RELAY_NODES=${CARDANO_RELAY_LIST} \
+  --diff \
+  -c local \
+  --limit localhost

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,86 @@
+data "aws_iam_policy_document" "ebs_eip_attach" {
+  for_each = local.aws_vm_default
+
+  # Policy allowing attaching the node's EBS volume
+  statement {
+    actions = [
+      "ec2:AttachVolume",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/Name"
+
+      values = [
+        each.value.name,
+      ]
+    }
+  }
+
+  statement {
+    actions = [
+      "ec2:DescribeVolumes",
+      "ec2:DescribeVolumeStatus",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  # Policy allowing attaching the node's EIP
+  statement {
+    actions = [
+      "ec2:AssociateAddress",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/Name"
+
+      values = [
+        each.value.name,
+      ]
+    }
+  }
+
+  # TODO: narrow the scope
+  statement {
+    actions = [
+      "ec2:DescribeAddresses",
+      "ec2:DescribeInstances",
+      "ec2:DescribeNetworkInterfaces",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+  # Policy allowing fetching ansible ZIP from S3
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${try(each.value.s3_bootstrap_bucket, local.bootstrap_bucket.name, each.key)}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "policy" {
+  for_each = local.aws_vm_default
+
+  name        = each.value.name
+  description = "Cardano node policy"
+  policy      = data.aws_iam_policy_document.ebs_eip_attach[each.key].json
+}

--- a/terraform/locals.aws.tf
+++ b/terraform/locals.aws.tf
@@ -142,4 +142,28 @@ locals {
     try(bucket.cloud_provider, "aws") == "aws"
   }
 
+  # Virtual Machines
+  aws_vm_default = { for idx, vm in local.vm_vars :
+    vm.name => vm if try(vm.enabled, true) &&
+    try(vm.cloud_provider, "aws") == "aws" &&
+    try(vm.region, "") == ""
+  }
+
+  aws_vm_sa_east1 = { for idx, vm in local.vm_vars :
+    vm.name => vm if try(vm.enabled, true) &&
+    try(vm.cloud_provider, "aws") == "aws" &&
+    try(vm.region, "") == "sa-east-1"
+  }
+
+  aws_vm_us_east1 = { for idx, vm in local.vm_vars :
+    vm.name => vm if try(vm.enabled, true) &&
+    try(vm.cloud_provider, "aws") == "aws" &&
+    try(vm.region, "") == "us-east-1"
+  }
+
+  aws_vm_us_east2 = { for idx, vm in local.vm_vars :
+    vm.name => vm if try(vm.enabled, true) &&
+    try(vm.cloud_provider, "aws") == "aws" &&
+    try(vm.region, "") == "us-east-2"
+  }
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,7 +1,12 @@
 locals {
-  config             = try(yamldecode(file("../config.yaml")), {})
+  config = try(yamldecode(file("../config.yaml")), {})
+
+  default_tags = try(local.config["default_tags"], {})
+
   ipaddress_vars     = try(local.config["ipaddress"], [])
   network_vars       = try(local.config["network"], [])
   objectstorage_vars = try(local.config["objectstorage"], [])
+  vm_vars            = try(local.config["virtual_machines"], [])
 
+  bootstrap_bucket = try([for os in local.objectstorage_vars : os if try(os.bootstrap, false)][0], false)
 }

--- a/terraform/virtualmachines.aws.tf
+++ b/terraform/virtualmachines.aws.tf
@@ -1,0 +1,124 @@
+locals {
+  # Get security group created within VPCs as specified by precedence of
+  # (virtual_machines.instances[x].vpc, virtual_machines.instances[x].name)
+  # With security group name precedence of
+  # (virtual_machines.instances[x].security_group_name, (virtual_machines.instances[x].name)
+  default_vms_sgs = flatten([
+    for vm in local.aws_vm_default : [
+      for sg in local.aws_sg_default : try(
+        module.aws_sg_default["${vm.vpc}#${vm.security_group_name}"].security_group_id,
+        module.aws_sg_default["${vm.vpc}#${vm.name}"].security_group_id,
+        module.aws_sg_default["${vm.name}#${vm.security_group_name}"].security_group_id,
+        module.aws_sg_default["${vm.name}#${vm.name}"].security_group_id,
+        []
+      ) if sg.vpc == try(vm.vpc, vm.name)
+    ]
+  ])
+
+  default_vpc_az = try([for az in module.aws_vpc_default["cardano-node"].azs : az if length(module.aws_vpc_default["cardano-node"].azs) == 1][0], false)
+
+  all_relays         = [for vm in local.vm_vars.instances : vm.name if try(vm.block_producer, false) == false]
+  vm_instance_relays = { for vm in local.vm_vars.instances : vm.name => try(vm.relays, local.all_relays) }
+
+}
+
+resource "aws_ebs_volume" "node_data" {
+  for_each = local.aws_vm_default
+
+  availability_zone = local.default_vpc_az != false ? local.default_vpc_az : try(each.value.az, local.vm_vars.default_availability_zone)
+
+  size = try(each.value.data_volume_size, local.vm_vars.default_data_volume_size, 120)
+  type = "gp3"
+
+  tags = merge(
+    local.default_tags,
+    {
+      Name = "node-${each.key}"
+    },
+  )
+}
+
+data "aws_ami" "instance_image" {
+  for_each = local.aws_vm_default
+
+  most_recent = try(each.value.ami.most_recent, true)
+
+  filter {
+    name   = "name"
+    values = try(each.value.ami.name, ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*"])
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = try(each.value.ami.virtualization_type, ["hvm"])
+  }
+
+  # Canonical
+  owners = try(each.value.ami.owners, ["099720109477"])
+}
+
+module "virtual_machines_default" {
+  source  = "terraform-aws-modules/autoscaling/aws"
+  version = "6.5.3"
+
+  for_each = local.aws_vm_default
+
+  name          = each.value.name
+  image_id      = data.aws_ami.instance_image[each.key].image_id
+  instance_type = try(each.value.instance_type, local.vm_vars.default_instance_type)
+  key_name      = try(each.value.key_name, null)
+
+  user_data = try(
+    base64encode(
+      templatefile(
+        "${path.root}/../templates/cloudinit/${try(each.value.cloudinit_template, "cardano-node.tftpl")}",
+        {
+          EBS_VOLUME_ID                   = aws_ebs_volume.node_data[each.key].id
+          OBJECT_STORAGE_BOOTSTRAP_BUCKET = local.bootstrap_bucket
+          CARDANO_RELAY_LIST              = local.vm_instance_relays[each.key]
+        }
+      ),
+    ),
+    null
+  )
+
+  min_size         = try(each.value.min_size, 1)
+  max_size         = try(each.value.max_size, 1)
+  desired_capacity = try(each.value.desired_capacity, 1)
+
+  health_check_type      = "EC2"
+  update_default_version = true
+  enable_monitoring      = true
+  vpc_zone_identifier    = try(module.aws_vpc_default[each.key].private_subnets, module.aws_vpc_default[each.key].private_subnets)
+
+  create_iam_instance_profile = true
+  iam_role_name               = each.value.name
+  iam_role_description        = "IAM role for instance ${each.value.name}"
+  iam_role_tags               = merge(local.default_tags, try(each.value.tags, {}))
+  iam_role_policies           = { (each.key) = aws_iam_policy.policy[each.key].arn }
+
+  security_groups = try(each.value.sg_ids, local.default_vms_sgs, null)
+
+  block_device_mappings = [
+    {
+      # Root volume
+      device_name = "/dev/xvda"
+      no_device   = 0
+      ebs = {
+        delete_on_termination = true
+        encrypted             = true
+        volume_size           = 20
+        volume_type           = "gp3"
+      }
+    }
+  ]
+
+  metadata_options = {
+    http_endpoint = "enabled"
+    # http_tokens                 = "required"
+    http_put_response_hop_limit = 32
+    instance_metadata_tags      = "enabled"
+  }
+
+  tags = merge(local.default_tags, try(each.value.tags, {}))
+}


### PR DESCRIPTION
- Add config stanza for virtualmachines
- Add initial pass at cloud-init from cardano-stake-pool repo slightly modified for templating.
- Add iam policies for instance principals

Known Issues:
- Virtual machines will not be importable from current state.  Will have to build and import EBS volume into TF state
- cardano-node.tftpl file is not currently valid.  Will have to alter depending on outcome of ansible collection.